### PR TITLE
Bugfix/select value

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+backend/lib/
+node_modules/
+.next/

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -111,7 +111,7 @@ export default function Dashboard() {
           </CardHeader>
           <CardContent>
             <Calendar
-              selectedDate={selectedDate}
+              value={selectedDate}
               onSelect={handleDateSelect}
               className="rounded-md border"
             />
@@ -127,7 +127,7 @@ export default function Dashboard() {
                 <SelectValue placeholder="グラウンドを選択" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">全てのグラウンド</SelectItem>
+                <SelectItem value="all">全てのグラウンド</SelectItem>
                 {uniqueFields.map((field) => (
                   <SelectItem key={field} value={field}>
                     {field}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -14,10 +14,22 @@ const logger = winston.createLogger({
     winston.format.colorize(),
     winston.format.splat(),
     winston.format.timestamp(),
-    winston.format.printf(({ timestamp, level, message, ...meta }: { timestamp: string; level: string; message: string; [key: string]: unknown }) => {
-      const metaString = Object.keys(meta).length ? safeStringify(meta) : "";
-      return `${timestamp} [${level}]: ${message} ${metaString}`;
-    })
+    winston.format.printf(
+      ({
+        timestamp,
+        level,
+        message,
+        ...meta
+      }: {
+        timestamp: string;
+        level: string;
+        message: string;
+        [key: string]: unknown;
+      }) => {
+        const metaString = Object.keys(meta).length ? safeStringify(meta) : "";
+        return `${timestamp} [${level}]: ${message} ${metaString}`;
+      }
+    )
   ),
   transports: [
     new winston.transports.Console(),


### PR DESCRIPTION
This pull request includes several changes to improve code readability, update component properties, and configure project settings. The most important changes include updates to the `.prettierignore` file, modifications to the `Dashboard` component, and formatting adjustments in the `logger` configuration.

### Project Configuration:

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R1-R3): Added `backend/lib/`, `node_modules/`, and `.next/` to the ignore list to prevent Prettier from formatting these directories.

### Component Updates:

* [`src/components/Dashboard.tsx`](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L114-R114): Updated `Calendar` component to use `value` instead of `selectedDate` for the date property.
* [`src/components/Dashboard.tsx`](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L130-R130): Changed the `SelectItem` value for "all fields" from an empty string to `"all"`.

### Code Formatting:

* [`src/lib/logger.ts`](diffhunk://#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27L17-R32): Reformatted the `printf` function in the Winston logger configuration for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `.prettierignore` file to streamline formatting by excluding specific directories.
	- Updated props in the `Dashboard` component for better compatibility with the `Calendar` and `SelectItem` components.

- **Bug Fixes**
	- Improved error handling in data fetching and notification saving processes.

- **Refactor**
	- Enhanced readability of the logger configuration without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->